### PR TITLE
feat(_sass/): table, th, td, img, img+em 관련 css를 추가한다

### DIFF
--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -37,6 +37,31 @@ blockquote {
   border-left: 4px solid #e6e6e6;
 }
 
+img {
+  display: block; 
+  margin: 0 auto;
+  width: 80%;
+}
+
+img + em {
+  display: block;
+  margin: 0 auto;
+  width: 80%;
+  text-align: center;
+  font-size: 0.8em;
+  margin-top: 5px;
+  color: #21252980;
+}
+
+table {
+  width: 100%
+}
+
+table, th, td {
+  border: 1px solid #ccc;
+  padding: 5px
+}
+
 .tags {
   .label {
     display: flex;

--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -1,32 +1,10 @@
 // Import Core Clean Blog SCSS
 @import "../assets/vendor/startbootstrap-clean-blog/scss/clean-blog.scss";
 
-.mermaid {
-  border: 1px solid;
-  border-radius: 10px;
-  padding: 20px;
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
 
 hr {
   margin-top: 20px;
   margin-bottom: 20px;
-}
-
-.photo-copyright {
-  font-size: 14px;
-  text-align: right;
-  margin-bottom: 50px;
-  > a {
-    font-weight: bold;
-  }
-}
-
-.recuit {
-  font-size: 17px;
-  font-weight: bold;
-  color: gray;
 }
 
 blockquote {
@@ -60,6 +38,30 @@ table {
 table, th, td {
   border: 1px solid #ccc;
   padding: 5px
+}
+
+
+.mermaid {
+  border: 1px solid;
+  border-radius: 10px;
+  padding: 20px;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.photo-copyright {
+  font-size: 14px;
+  text-align: right;
+  margin-bottom: 50px;
+  > a {
+    font-weight: bold;
+  }
+}
+
+.recuit {
+  font-size: 17px;
+  font-weight: bold;
+  color: gray;
 }
 
 .tags {


### PR DESCRIPTION
기존에 없던 css 스타일을 추가합니다.

- 테이블의 선이 보이도록 추가했습니다.
- 이미지 뒤에 em 태그를 붙이면 이미지 캡션으로 들어갈 수 있도록 추가해두었습니다.
- css 파일 내 컴포넌트들의 순서를 html -> 클래스 순서로 바꾸었습니다.

as-is

![image](https://user-images.githubusercontent.com/62049738/147056143-025f5acc-d592-48ee-b605-572faa894875.png)

![image](https://user-images.githubusercontent.com/62049738/147056333-83f0e4fb-db7c-4fc5-a530-8d09ed7189c3.png)


to-be

![image](https://user-images.githubusercontent.com/62049738/147056158-40f498a2-f607-4db7-85b5-fa2e72737f3a.png)

![image](https://user-images.githubusercontent.com/62049738/147056381-3ce09ee2-f038-4651-b214-d43bea7b4cfd.png)


