### PR TITLE
feat: toc의 color와 font-weight을 수정합니다

### DIFF
--- a/_sass/styles.scss
+++ b/_sass/styles.scss
@@ -247,10 +247,14 @@ header.masthead {
   transform: translate(0, -50%);
   padding: 20px;
   line-height: 100%;
-  color: #00000090;
+  color: black;
   font-weight: 300;
   visibility: visible;
   transition: all 0.4s cubic-bezier(0.25, 0.8, 0.4, 0.95);
+
+  .is-active-link {
+    font-weight: 400;
+  }
 }
 
 .toc-hidden {


### PR DESCRIPTION
글씨 색상이 너무 약해 잘 안보여서 색상을 더 진하게 키우고,
마우스 오버시 너무 강한 weight를 조금 줄였습니다.

to-be

![image](https://user-images.githubusercontent.com/62049738/148235851-968f51d6-9776-40a1-a0ab-3c0be732e9c0.png)

이 브랜치는 #96 머지 후에 리베이스 해야합니다.
