### PR TITLE
refactor: fix meta description content

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,18 +8,19 @@
     {% else %}{{ site.title | escape }}{% endif %}
   </title>
 
-  <meta name="description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}">
+  <meta name="description" content="{{ page.description | default: page.subtitle | strip_html | normalize_whitespace | truncate: 160 | escape }}">
 
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="{{ site.url }}{{ page.url }}"/>
   <meta property="og:title" content="{{ page.title }}"/>
-  <meta property="og:description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}"/>
+  <meta property="og:description" content="{{ page.description | default: page.subtitle | strip_html | normalize_whitespace | truncate: 160 | escape }}"/>
   <meta property="og:site_name" content="{{ site.title }}"/>
   <meta property="og:image" content="{{ site.url }}{{ page.background }}"/>
   <meta name="twitter:card" content="summary_large_image"/>
   <meta name="twitter:title" content="{{ page.title }}"/>
-  <meta name="twitter:description" content="{{ page.excerpt | default: site.description | strip_html | normalize_whitespace | truncate: 160 | escape }}"/>
+  <meta name="twitter:description" content="{{ page.description | default: page.subtitle | strip_html | normalize_whitespace | truncate: 160 | escape }}"/>
   <meta name="twitter:image" content="{{ site.url }}{{ page.background }}"/>
+
 
   <link href='https://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic' rel='stylesheet' type='text/css'>
   <link href='https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,800italic,400,300,600,700,800' rel='stylesheet' type='text/css'>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -37,7 +37,7 @@ layout: default
             {% if post.subtitle %}
             <h3 class="post-subtitle">{{ post.subtitle }}</h3>
             {% else %}
-            <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
+            <h3 class="post-subtitle">{{ post.description | strip_html | truncatewords: 15 }}</h3>
             {% endif %}
           </a>
           <div class="post-meta">

--- a/posts/index.html
+++ b/posts/index.html
@@ -11,7 +11,7 @@ background: '/assets/images/home-bg-main-1.png'
     {% if post.subtitle %}
     <h3 class="post-subtitle">{{ post.subtitle }}</h3>
     {% else %}
-    <h3 class="post-subtitle">{{ post.excerpt | strip_html | truncatewords: 15 }}</h3>
+    <h3 class="post-subtitle">{{ post.description | strip_html | truncatewords: 15 }}</h3>
     {% endif %}
   </a>
   <div class="post-meta">


### PR DESCRIPTION
쏘카 기술블로그 글들에 보다 정확한 메타데이터를 넣어주기 위해
post.md > metadata에 description을 작성하면 해당 description을 meta 태그에 넣어주고, description을 작성하지 않으면 subtitle을 넣어주도록 수정

description O
```markdown
---
layout: post
title: "React Custom Icon Component 개발기"
subtitle: "아이콘 등록 프로세스 효율화를 통한 개발자 경험(Developer Experience) 개선"
description: "아이콘 등록 프로세스 효율화"
---
```
==>
```html
<meta name="description" content="아이콘 등록 프로세스 효율화">
```

description X
```markdown
---
layout: post
title: "React Custom Icon Component 개발기"
subtitle: "아이콘 등록 프로세스 효율화를 통한 개발자 경험(Developer Experience) 개선"
---
```
==>
```html
<meta name="description" content="아이콘 등록 프로세스 효율화를 통한 개발자 경험(Developer Experience) 개선">
```